### PR TITLE
Note for loading resolution-aware image assets

### DIFF
--- a/src/docs/development/ui/assets-and-images.md
+++ b/src/docs/development/ui/assets-and-images.md
@@ -233,6 +233,10 @@ awareness when loading images. (If you work with some of the lower
 level classes, like [`ImageStream`][] or [`ImageCache`][],
 you'll also notice parameters related to scale.)
 
+{{site.alert.note}}
+  [device pixel ratio][] depends on [MediaQueryData.size][] which requires to have either [MaterialApp][] or [CupertinoApp][] as ancestor of your [`AssetImage`][]
+{{site.alert.end}}
+
 ### Asset images in package dependencies {#from-packages}
 
 To load an image from a [package][] dependency,
@@ -508,3 +512,6 @@ For more details, see
 [`video_player` plugin]: {{site.pub}}/packages/video_player
 [`window.onDrawFrame`]: {{site.api}}/flutter/dart-ui/Window/onDrawFrame.html
 [`window.render()`]: {{site.api}}/flutter/dart-ui/Window/render.html
+[MediaQueryData.size]: {{site.api}}/flutter/widgets/MediaQueryData/size.html
+[MaterialApp]: {{site.api}}/flutter/material/MaterialApp-class.html
+[CupertinoApp]: {{site.api}}/flutter/cupertino/CupertinoApp-class.html

--- a/src/docs/development/ui/assets-and-images.md
+++ b/src/docs/development/ui/assets-and-images.md
@@ -234,7 +234,7 @@ level classes, like [`ImageStream`][] or [`ImageCache`][],
 you'll also notice parameters related to scale.)
 
 {{site.alert.note}}
-  [device pixel ratio][] depends on [MediaQueryData.size][] which requires to have either [MaterialApp][] or [CupertinoApp][] as ancestor of your [`AssetImage`][]
+  [device pixel ratio][] depends on [MediaQueryData.size][] which requires to have either a [MaterialApp][] or [CupertinoApp][] as an ancestor of your [`AssetImage`][].
 {{site.alert.end}}
 
 ### Asset images in package dependencies {#from-packages}

--- a/src/docs/development/ui/assets-and-images.md
+++ b/src/docs/development/ui/assets-and-images.md
@@ -234,7 +234,7 @@ level classes, like [`ImageStream`][] or [`ImageCache`][],
 you'll also notice parameters related to scale.)
 
 {{site.alert.note}}
-  [device pixel ratio][] depends on [MediaQueryData.size][] which requires to have either a [MaterialApp][] or [CupertinoApp][] as an ancestor of your [`AssetImage`][].
+  [Device pixel ratio][] depends on [MediaQueryData.size][] which requires to have either a [MaterialApp][] or [CupertinoApp][] as an ancestor of your [`AssetImage`][].
 {{site.alert.end}}
 
 ### Asset images in package dependencies {#from-packages}
@@ -515,3 +515,4 @@ For more details, see
 [MediaQueryData.size]: {{site.api}}/flutter/widgets/MediaQueryData/size.html
 [MaterialApp]: {{site.api}}/flutter/material/MaterialApp-class.html
 [CupertinoApp]: {{site.api}}/flutter/cupertino/CupertinoApp-class.html
+[Device pixel ratio]: {{site.api}}/flutter/dart-ui/Window/devicePixelRatio.html


### PR DESCRIPTION
This note describes that `AssetImage` must have an ancestor of either `MaterialApp` or `CupertinoApp` to work 